### PR TITLE
More optional history logging

### DIFF
--- a/src/ArnoldiMethod.jl
+++ b/src/ArnoldiMethod.jl
@@ -6,12 +6,13 @@ using StaticArrays
 using Base: RefValue, OneTo
 
 export partialschur, LM, SR, LR, SI, LI, partialeigen
+export History, GeneralHistory, DetailedHistory
 
 """
     Arnoldi(n, k) → Arnoldi
 
 Pre-allocated Arnoldi relation of the Vₖ₊₁ and Hₖ matrices that satisfy
-A * Vₖ = Vₖ₊₁ * Hₖ, where Vₖ₊₁ is orthonormal of size n × (k+1) and Hₖ upper 
+A * Vₖ = Vₖ₊₁ * Hₖ, where Vₖ₊₁ is orthonormal of size n × (k+1) and Hₖ upper
 Hessenberg of size (k+1) × k. The constructor will just allocate sufficient
 space, but will *not* initialize the first vector of `v₁`. For the latter see
 `reinitialize!`.
@@ -23,7 +24,7 @@ struct Arnoldi{T,TV<:StridedMatrix{T},TH<:StridedMatrix{T}}
     function Arnoldi{T}(matrix_order::Int, krylov_dimension::Int) where {T}
         krylov_dimension <= matrix_order || throw(ArgumentError("Krylov dimension should be less than matrix order."))
         V = Matrix{T}(undef, matrix_order, krylov_dimension + 1)
-        H = zeros(T, krylov_dimension + 1, krylov_dimension)    
+        H = zeros(T, krylov_dimension + 1, krylov_dimension)
         return new{T,typeof(V),typeof(H)}(V, H)
     end
 end
@@ -31,9 +32,9 @@ end
 """
     RitzValues(maxdim) → RitzValues
 
-Convenience wrapper for Ritz values + residual norms and some permutation of 
-these values. The Ritz values are computed from the active part of the 
-Hessenberg matrix `H[active:maxdim,active:maxdim]`. 
+Convenience wrapper for Ritz values + residual norms and some permutation of
+these values. The Ritz values are computed from the active part of the
+Hessenberg matrix `H[active:maxdim,active:maxdim]`.
 
 When computing exact shifts in the implicit restart, we need to reorder the Ritz
 values in some way. For convenience we simply keep track of a permutation `ord`
@@ -58,9 +59,9 @@ end
 
 Holds an orthonormal basis `Q` and a (quasi) upper triangular matrix `R`.
 
-For convenience the eigenvalues that appear on the diagonal of `R` are also 
-listed as `eigenvalues`, which is in particular useful in the case of real 
-matrices with complex eigenvalues. Note that the eigenvalues are always a 
+For convenience the eigenvalues that appear on the diagonal of `R` are also
+listed as `eigenvalues`, which is in particular useful in the case of real
+matrices with complex eigenvalues. Note that the eigenvalues are always a
 complex, even when the matrix `R` is real.
 """
 struct PartialSchur{TQ,TR,Tλ<:Complex}


### PR DESCRIPTION
This adds additional optional logging. This is useful when the Arnoldi-method fails. 

It is e.g. quite easy to investigate what is going wrong in #93 with this:
```julia
@load "myerror.jld2" W
local history;
for k=1:30
    decomp, history = partialschur(W, nev=3, which=LR(), tol=1e-13, history_level=DetailedHistory);
    λ, V = partialeigen(decomp);
    if (abs(maximum(real(λ)) - maximum(real(eigvals(W)))) > 1e-6)
        break;
   end
end
```
The eigenvalues that should be computed are
```julia
julia> e=eigvals(W); II=sortperm(-real(e)); e[II[1:3]]
3-element Array{Complex{Float64},1}:
  0.15368465993022115 + 0.0im                  
 9.871248233586328e-9 + 1.0327891056793643e-8im
 9.871248233586328e-9 - 1.0327891056793643e-8im
```
It seems the two last eigenvalues are incorrectly locked in the first restart:
```julia
julia> history.ritzval_history[1][history.ritzval_lock_history[1]]
2-element Array{Complex{Float64},1}:
 3.5489275362237446e-7 + 0.00012663869814285724im
 3.5489275362237446e-7 - 0.00012663869814285724im
```

The PR is not quite ready yet. Putting it here for comments. What should be collected?