### PR TITLE
Preallocate workspace

### DIFF
--- a/src/ArnoldiMethod.jl
+++ b/src/ArnoldiMethod.jl
@@ -72,6 +72,49 @@ struct PartialSchur{TQ,TR,Tλ<:Complex}
     eigenvalues::Vector{Tλ}
 end
 
+
+
+struct Reflector{T}
+    vec::Vector{T}
+    offset::RefValue{Int}
+    len::RefValue{Int}
+    τ::RefValue{T}
+
+    Reflector{T}(max_len::Int) where {T} = new{T}(
+        Vector{T}(undef, max_len),
+        Base.RefValue(1),
+        Base.RefValue(0),
+        Base.RefValue(zero(T))
+    )
+end
+
+
+struct PartialSchurWorkspace{T}
+    arnoldi::Arnoldi{T}
+    Vtmp::Matrix{T}
+    Q::Matrix{T}
+    x::Vector{Complex{T}}
+    G::Reflector{T}
+    ritz::RitzValues{Complex{T}, T}
+    groups::Vector{Int}
+    n::Int
+    maxdim::Int
+
+    function PartialSchurWorkspace{T}(n, maxdim) where T      
+        arnoldi = Arnoldi{T}(n, maxdim)
+        Vtmp = Matrix{T}(undef, n, maxdim)
+        Q = Matrix{T}(undef, maxdim, maxdim)
+        x = Vector{Complex{T}}(undef, maxdim)
+        G = Reflector{T}(maxdim)   
+        ritz = RitzValues{T}(maxdim)
+        groups = Vector{Int}(undef, maxdim)
+        return new{T}(arnoldi, Vtmp, Q, x, G, ritz, groups, n, maxdim)
+    end
+
+end
+
+
+
 include("targets.jl")
 include("partition.jl")
 include("schurfact.jl")

--- a/src/restore_hessenberg.jl
+++ b/src/restore_hessenberg.jl
@@ -44,19 +44,6 @@ function reflector!(y::AbstractVector{T}, k::Integer) where {T}
     end
 end
 
-struct Reflector{T}
-    vec::Vector{T}
-    offset::RefValue{Int}
-    len::RefValue{Int}
-    τ::RefValue{T}
-
-    Reflector{T}(max_len::Int) where {T} = new{T}(
-        Vector{T}(undef, max_len),
-        Base.RefValue(1),
-        Base.RefValue(0),
-        Base.RefValue(zero(T))
-    )
-end
 
 function reflector!(z::Reflector, k::Integer)
     z.len[] = k


### PR DESCRIPTION
I've been using this package to solve a very large number of small eigenproblems in parallel. Owing to the large number of solves my runtime was dominated by allocation, so I had to factor out the allocation routines in the partial Schur factorisation.

The PR is a draft as I haven't tested it beyond my own requirements. 

If this is of use to a wider audience, I'm happy to clean it up as required. If not, I'm equally happy to close it and maintain a fork.

P.S. Performance is excellent, thanks for your work on this @haampie .
