### PR TITLE
Update links to documentation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@
 The Implicitly Restarted Arnoldi Method, natively in Julia.
 
 ## Docs
-[![Stable docs](https://img.shields.io/badge/docs-stable-blue.svg)](https://haampie.github.io/ArnoldiMethod.jl/stable) [![Latest docs](https://img.shields.io/badge/docs-latest-gray.svg)](https://haampie.github.io/ArnoldiMethod.jl/latest)
+[![Stable docs](https://img.shields.io/badge/docs-stable-blue.svg)](https://julialinearalgebra.github.io/ArnoldiMethod.jl/stable) [![Latest docs](https://img.shields.io/badge/docs-latest-gray.svg)](https://julialinearalgebra.github.io/ArnoldiMethod.jl/latest)
 
 ## Goal
 Make `eigs` a native Julia function.


### PR DESCRIPTION
Since you moved to JuliaLinearAlgebra organization, the links to the documentation broke. Instead of opening an issue, I thought I'll just fix it.

The other badges (Codecov, Travis) probably won't work as well, but I don't think I can change that.