### PR TITLE
changed StaticArrays compat to "... 1" (was 1.0)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
-StaticArrays = "0.8, 0.9, 0.10, 0.11, 0.12, 1.0"
+StaticArrays = "0.8, 0.9, 0.10, 0.11, 0.12, 1"
 julia = "1.3"
 
 [extras]


### PR DESCRIPTION
This appears to be a way to free a version conflict with other packages (StaticArrays is at v"1.4.x" today)