### PR TITLE
Update Documenter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,25 @@ jobs:
         with:
           file: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
+  docs:
+    name: Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: '1'
+      - run: |
+          julia --project=docs -e '
+            using Pkg
+            Pkg.develop(PackageSpec(path=pwd()))
+            Pkg.instantiate()'
+      - run: |
+          julia --project=docs -e '
+            using Documenter: doctest
+            using ArnoldiMethod
+            doctest(ArnoldiMethod)'
+      - run: julia --project=docs docs/make.jl
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,5 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+
+[compat]
+Documenter = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,26 +1,24 @@
 using Documenter, ArnoldiMethod
 
 makedocs(
-	modules = [ArnoldiMethod],
-	format = :html,
-	doctest = false,
-	clean = true,
-	sitename = "ArnoldiMethod.jl",
-	pages = [
-		"Home" => "index.md",
-		"Theory" => "theory.md",
-		"Using ArnoldiMethod.jl" => [
-			"Getting started" => "usage/01_getting_started.md",
-			"Transformations" => "usage/02_spectral_transformations.md"
-		]
+    modules = [ArnoldiMethod],
+    sitename = "ArnoldiMethod.jl",
+    format = Documenter.HTML(),
+    pages = [
+	"Home" => "index.md",
+	"Theory" => "theory.md",
+	"Using ArnoldiMethod.jl" => [
+	    "Getting started" => "usage/01_getting_started.md",
+	    "Transformations" => "usage/02_spectral_transformations.md"
 	]
+    ],
+    warnonly = [:missing_docs, :cross_references],
 )
 
+# Documenter can also automatically deploy documentation to gh-pages.
+# See "Hosting Documentation" and deploydocs() in the Documenter manual
+# for more information.
 deploydocs(
-	repo = "github.com/JuliaLinearAlgebra/ArnoldiMethod.jl.git",
-	target = "build",
-	osname = "linux",
-	julia  = "0.7",
-	deps = nothing,
-	make = nothing,
+    repo = "github.com/JuliaSparse/KLU.jl.git",
+    devbranch="main"
 )


### PR DESCRIPTION
Documentation update needs to be added to ci.yml after this is merged. This gets Documenter.jl 1.0 working.