### PR TITLE
Add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,4 +7,3 @@ authors:
   given-names: "Lauri"
 title: "ArnoldiMethod.jl"
 url: "https://github.com/JuliaLinearAlgebra/ArnoldiMethod.jl"
-

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,10 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+authors:
+- family-names: "Stoppels"
+  given-names: "Harmen"
+- family-names: "Nyman"
+  given-names: "Lauri"
+title: "ArnoldiMethod.jl"
+url: "https://github.com/JuliaLinearAlgebra/ArnoldiMethod.jl"
+


### PR DESCRIPTION
Missing identifiers, not sure if required.

For Zenodo generated identifiers the application needs access to the organization.

Closes #115 
