### PR TITLE
Allow `which` symbols like in Arpack.jl and KrylovKit.jl

### DIFF
--- a/bench/example.jl
+++ b/bench/example.jl
@@ -9,7 +9,7 @@ using Arpack
 
 function helloworld(n = 40, nev = 4)
     A = randn(n, n)
-    @time S, hist = partialschur(A, nev = nev, which = LR(), tol = 1e-6)
+    @time S, hist = partialschur(A, nev = nev, which = :LR, tol = 1e-6)
     @time eigs(A, nev = nev, which = :LR, tol = 1e-6)
     @show norm(A * S.Q - S.Q * S.R)
     println(hist)

--- a/bench/partial_schur.jl
+++ b/bench/partial_schur.jl
@@ -37,7 +37,7 @@ end
 function bencharnoldi()
     A = mymatrix(6000)
     A = construct_linear_map(mymatrix(6000))
-    target = LM()
+    target = :LM
 
     @benchmark partialschur(
         B,

--- a/docs/src/usage/01_getting_started.md
+++ b/docs/src/usage/01_getting_started.md
@@ -43,7 +43,7 @@ julia> A = spdiagm(
             0 => fill(2.0, 100), 
             1 => fill(-1.0, 99)
        );
-julia> decomp, history = partialschur(A, nev=10, tol=1e-6, which=SR());
+julia> decomp, history = partialschur(A, nev=10, tol=1e-6, which=:SR);
 julia> decomp
 PartialSchur decomposition (Float64) of dimension 10
 eigenvalues:

--- a/docs/src/usage/02_spectral_transformations.md
+++ b/docs/src/usage/02_spectral_transformations.md
@@ -27,7 +27,7 @@ function construct_linear_map(A)
 end
 
 # Target the largest eigenvalues of the inverted problem
-decomp, = partialschur(construct_linear_map(A), nev=4, tol=1e-5, restarts=100, which=LM())
+decomp, = partialschur(construct_linear_map(A), nev=4, tol=1e-5, restarts=100, which=:LM)
 λs_inv, X = partialeigen(decomp)
 
 # Eigenvalues have to be inverted to find the smallest eigenvalues of the non-inverted problem.
@@ -65,7 +65,7 @@ function construct_linear_map(A,B)
 end
 
 # Target the largest eigenvalues of the inverted problem
-decomp,  = partialschur(construct_linear_map(A, B), nev=4, tol=1e-5, restarts=100, which=LM())
+decomp,  = partialschur(construct_linear_map(A, B), nev=4, tol=1e-5, restarts=100, which=:LM)
 λs_inv, X = partialeigen(decomp)
 
 # Eigenvalues have to be inverted to find the smallest eigenvalues of the non-inverted problem.

--- a/readme.md
+++ b/readme.md
@@ -31,7 +31,7 @@ julia> A = spdiagm(
             1 => fill(-1.0, 99)
        );
 
-julia> decomp, history = partialschur(A, nev=10, tol=1e-6, which=SR());
+julia> decomp, history = partialschur(A, nev=10, tol=1e-6, which=:SR);
 
 julia> decomp
 PartialSchur decomposition (Float64) of dimension 10

--- a/test/partial_schur.jl
+++ b/test/partial_schur.jl
@@ -52,7 +52,7 @@ end
 @testset "Target non-dominant eigenvalues" begin
     # Dominant eigenvalues 50, 51, 52, 53, but we target the smallest real part
     A = Diagonal([1:0.1:10; 50:53])
-    S, hist = partialschur(A, which = SR())
+    S, hist = partialschur(A, which = :SR)
     @test all(x -> real(x) ≤ 10, eigenvalues(S.R))
 end
 


### PR DESCRIPTION
:LM, :LR, :SR, :LI, and :SI in addition to LM(), LR(), SR(), LI(), and SI().

I guess this was previously not implemented because type stability was considered a big thing.
