### PR TITLE
do not export LM, SR, LR, SI, LI

### DIFF
--- a/src/ArnoldiMethod.jl
+++ b/src/ArnoldiMethod.jl
@@ -5,7 +5,7 @@ using StaticArrays
 
 using Base: RefValue, OneTo
 
-export partialschur, partialschur!, LM, SR, LR, SI, LI, partialeigen, ArnoldiWorkspace
+export partialschur, partialschur!, partialeigen, ArnoldiWorkspace
 
 """
     ArnoldiWorkspace(n, k) → ArnoldiWorkspace

--- a/src/run.jl
+++ b/src/run.jl
@@ -47,6 +47,9 @@ The target `which` can be any of:
 | `:LI` or `LI()` | Largest imaginary part: `imag(λ)` is largest   |
 | `:SI` or `SI()` | Smallest imaginary part: `imag(λ)` is smallest |
 
+Note that as of ArnoldiMethod v0.4, you have to import `using ArnoldiMethod: LM` explicitly if you
+do not want to use symbols.
+
 !!! note
 
     The targets `:LI` and `:SI` only make sense in complex arithmetic. In real


### PR DESCRIPTION
Cause users can pass `:LM`, `:SR`, `:LR`, `:SI`, `:LI` instead, and it's
somewhat weird to export obscure 2 character struct names.

