### PR TITLE
Simplify CI architectures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,33 +14,27 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'  # Oldest version supported by this package
           - '1'    # Current stable version
         os:
           - ubuntu-latest
           - windows-latest
-          - macOS-13 # intel
-          - macOS-14 # arm
+          - macOS-latest
         arch:
           - x64
-          - x86
-          - aarch64
-        exclude:
+        include:
+          - os: macOS-14
+            arch: aarch64
+            version: '1'
           - os: ubuntu-latest
-            arch: aarch64
-          - os: windows-latest
-            arch: aarch64
-          - os: macOS-13
             arch: x86
-          - os: macOS-13
-            arch: aarch64
-          - os: macOS-14
-            arch: x86
-          - os: macOS-14
+            version: '1'
+          - os: ubuntu-latest
             arch: x64
-          - os: macOS-14
-            arch: aarch64
-            version: '1.6'    
+            version: '1.6'
+          - os: ubuntu-latest
+            arch: x64
+            version: 'nightly'
+
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v1


### PR DESCRIPTION
Reduce number of combinations run, and use includes rather than excludes.