### PR TITLE
prevent out of bounds access in local_schurfact!

### DIFF
--- a/src/schurfact.jl
+++ b/src/schurfact.jl
@@ -500,7 +500,7 @@ function local_schurfact!(
     # iteration count
     iter = 0
 
-    @inbounds while true
+    @inbounds while to > start
         iter += 1
         iter > maxiter && return false
 


### PR DESCRIPTION
This fix is to prevent the out of bounds access in #149.

The while loop condition in the generic version of local_schurfact is changed to match the condition in real version. 